### PR TITLE
Fix case sensitivity in game assets

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,4 +36,5 @@ dependencies {
     implementation(libs.ktor.server.config.yaml)
     testImplementation(libs.ktor.server.test.host)
     testImplementation(libs.kotlin.test.junit)
+    implementation("io.github.classgraph:classgraph:4.8.181")
 }

--- a/src/main/kotlin/module/CaseInsensitiveStaticResources.kt
+++ b/src/main/kotlin/module/CaseInsensitiveStaticResources.kt
@@ -1,0 +1,79 @@
+package dev.deadzone.module
+
+import io.github.classgraph.ClassGraph
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.defaultForFileExtension
+import io.ktor.server.application.Application
+import io.ktor.server.request.path
+import io.ktor.server.response.respond
+import io.ktor.server.response.respondBytes
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+
+fun Application.caseInsensitiveStaticResources(baseUrl: String, resourceRoot: String = "static") {
+    val resourceMap = scanClasspathResources(resourceRoot)
+
+    for (key in resourceMap.keys) {
+        println("$key -> ${resourceMap[key]}")
+    }
+
+    routing {
+        get("$baseUrl/{...}") {
+            val rawPath = call.request.path().replace(Regex("/+"), "/")
+            val lookupKey = if (rawPath.startsWith("/game/data")) {
+                "static" + rawPath.lowercase()
+            } else {
+                "static$rawPath"
+            }
+
+
+            val actualResourcePath = resourceMap[lookupKey]
+
+            println("🔶 Serving $rawPath")
+            println("lookupKey: $lookupKey")
+            println("actual: $actualResourcePath")
+
+            if (actualResourcePath != null) {
+                val resource = Application::class.java.getResourceAsStream("/$actualResourcePath")
+                if (resource != null) {
+                    val contentType = ContentType.defaultForFileExtension(
+                        rawPath.substringAfterLast('.', "")
+                    )
+                    return@get call.respondBytes(resource.readBytes(), contentType)
+                }
+            }
+
+            call.respond(HttpStatusCode.NotFound)
+        }
+
+        // Special case for serving / (root) as index.html (case-sensitive)
+        get(baseUrl) {
+            println("🔶 Serving index.html")
+            val indexPath = "$resourceRoot/index.html"
+            val stream =
+                resourceMap[indexPath]?.let { this::class.java.classLoader.getResourceAsStream(it) }
+
+            if (stream != null) {
+                return@get call.respondBytes(stream.readBytes(), ContentType.Text.Html)
+            }
+
+            call.respond(HttpStatusCode.NotFound)
+        }
+    }
+}
+
+fun scanClasspathResources(basePackage: String): Map<String, String> {
+    val map = mutableMapOf<String, String>()
+
+    ClassGraph().acceptPaths(basePackage).scan().use { scanResult ->
+        for (res in scanResult.allResources) {
+            val fullPath = res.path                      // e.g. static/game/data/models/...
+            map[fullPath] = fullPath                     // exact‑case key  ( still useful )
+            if (fullPath.startsWith("$basePackage/game/data/", ignoreCase = true)) {
+                map[fullPath.lowercase()] = fullPath     // case‑insensitive alias
+            }
+        }
+    }
+    return map
+}

--- a/src/main/kotlin/module/Routing.kt
+++ b/src/main/kotlin/module/Routing.kt
@@ -11,7 +11,7 @@ import java.io.File
 
 fun Application.configureRouting(db: BigDB) {
     routing {
-        staticResources("/", "static")
+        caseInsensitiveStaticResources("/", "static")
         staticFiles("/game/core.swf", File("core-swf/core.swf"))
 
         post("/api/{path}") {


### PR DESCRIPTION
> * This should work on all platforms
> * ChatGPT used to produce this so review with caution please
> * You may need to remove print lines after review

Serve static resources with case-insensitivity for paths under `/game/data`

This change introduces a new module, `CaseInsensitiveStaticResources`, which uses `ClassGraph` to scan classpath resources.

For requests under `/game/data`, the resource lookup is now case-insensitive. All other static resource paths remain case-sensitive.
The root path `/` will serve `static/index.html` (case-sensitive).

The dependency `io.github.classgraph:classgraph:4.8.181` has been added.